### PR TITLE
Fix Debounce Test Timer Handling (Issue #76)

### DIFF
--- a/vscode-extension/src/services/AiAssistanceService.test.ts
+++ b/vscode-extension/src/services/AiAssistanceService.test.ts
@@ -15,20 +15,15 @@ describe('AiAssistanceService', () => {
   let mockMCPClient: jest.Mocked<MCPClient>;
 
   beforeEach(() => {
-    // Reset the singleton instance before each test
-    (MCPClient as any).resetInstance();
-    
-    // Create a mock MCPClient instance
+    // Create a mock MCPClient instance with all required methods
     mockMCPClient = {
       askQuestion: jest.fn(),
-      getInstance: jest.fn(),
     } as any;
 
     // Mock the getInstance static method to return our mock
-    (MCPClient.getInstance as jest.Mock).mockReturnValue(mockMCPClient);
+    jest.spyOn(MCPClient, 'getInstance').mockReturnValue(mockMCPClient);
 
     service = new AiAssistanceService();
-    mockMCPClient = MCPClient.getInstance() as jest.Mocked<MCPClient>;
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
Fixed the debounce test in `AiAssistanceService.test.ts` that was failing due to improper Jest mock setup for the MCPClient singleton.

## Changes Made
- **Fixed MCPClient mock setup**: Changed from attempting to call non-existent `resetInstance()` to using `jest.spyOn(MCPClient, 'getInstance')`
- **Removed redundant code**: Eliminated unnecessary mock reassignment
- **Simplified mock creation**: Streamlined the mock instance creation in `beforeEach()`

## Root Cause
The test was failing because:
1. It tried to call `(MCPClient as any).resetInstance()` which doesn't exist
2. The mock setup was trying to mock `getInstance` as an instance method instead of a static method
3. This caused all tests to fail with "mockReturnValue is not a function"

## Solution
The debounce test itself was already properly implemented using real timers with a 1ms delay (avoiding the fake timer async/await issues mentioned in the issue). The actual problem was the mock setup preventing any tests from running.

The fix uses `jest.spyOn()` to properly mock the static `getInstance()` method, allowing all 8 tests to pass successfully.

## Test Results
```
✅ All 8 tests passing
✅ Debounce test completes in 9ms (no timeout)
✅ Verifies only 1 MCP call made for 3 rapid requests
✅ All 3 promises receive the same result
```

## Verification
```bash
npm run test:jest -- AiAssistanceService.test.ts
# Test Suites: 1 passed, 1 total
# Tests: 8 passed, 8 total
```

Closes #76